### PR TITLE
Fix package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Configurations are opinionated and strict. We aim to catch as many possible mist
 Install dependencies:
 
 ```bash
-npm install --save-dev prettier eslint @stanfordbdhg/spezi-web-configurations`
+npm install --save-dev prettier eslint @stanfordspezi/spezi-web-configurations`
 ```
 
 Create `eslint.config.js` file:
 
 ```javascript
-const { getEslintConfig } = require('@stanfordbdhg/spezi-web-configurations')
+const { getEslintConfig } = require('@stanfordspezi/spezi-web-configurations')
 
 module.exports = getEslintConfig({ tsconfigRootDir: __dirname })
 ```
@@ -39,7 +39,7 @@ module.exports = getEslintConfig({ tsconfigRootDir: __dirname })
 Create `.prettierrc.js` file:
 
 ```javascript
-const { prettierConfig } = require("@stanfordbdhg/spezi-web-configurations");
+const { prettierConfig } = require("@stanfordspezi/spezi-web-configurations");
 
 module.exports = prettierConfig;
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "@stanfordbdhg/spezi-web-configurations",
+  "name": "@stanfordspezi/spezi-web-configurations",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@stanfordbdhg/spezi-web-configurations",
+      "name": "@stanfordspezi/spezi-web-configurations",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stanfordbdhg/spezi-web-configurations",
+  "name": "@stanfordspezi/spezi-web-configurations",
   "private": true,
   "description": "Stanford Biodesign Digital Health Spezi Web Configurations",
   "keywords": [
@@ -7,7 +7,11 @@
     "Biodesign",
     "Spezi",
     "Web",
-    "Configurations"
+    "Configurations",
+    "ESLint",
+    "Prettier",
+    "linting",
+    "formatting"
   ],
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "parcel build",
-    "dev": "vite",
+    "dev": "parcel watch",
     "lint": "eslint .",
     "lint:ci": "eslint --output-file eslint_report.json --format json .",
     "lint:fix": "eslint . --fix"


### PR DESCRIPTION
# Fix package name

## :recycle: Current situation & Problem
`@stanfordspezi` is a correct name for Spezi packages.

## :gear: Release Notes 
* Replace `@stanfordbdhg` with `@stanfordspezi`


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
