### PR TITLE
Ignore `import/no-default-export` for known default exports usage

### DIFF
--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -154,9 +154,11 @@ export const getEslintConfig = ({ tsconfigRootDir }: EslintConfigParams) =>
     eslintPluginPrettierRecommended,
     {
       files: [
-        "app/**/*.ts?(x)",
-        "**/*.stories.ts?(x)",
+        "playwright.config.ts",
+        "tailwind.config.ts",
         "vite.config.ts",
+        "{app,pages}/**/*.ts?(x)",
+        "**/*.stories.ts?(x)",
         ".storybook/**/*.ts?(x)",
       ],
       rules: {


### PR DESCRIPTION
# Ignore `import/no-default-export` for known default exports usage

## :recycle: Current situation & Problem
Some tooling, packages use default exports as part of it's tooling. We have to ignore known cases. 


## :gear: Release Notes 
* Ignore `import/no-default-export` for known default exports usage


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
