### PR TITLE
Add `tsConfigsDirs` param

### DIFF
--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -18,12 +18,20 @@ const importPlugin = require("eslint-plugin-import");
 type EslintConfigParams = {
   /**
    * Root of the project, where tsconfig exists.
-   * Most likely it's going to be `import.meta.dirname` or `__dirname`
+   * Most likely it's going to be `import.meta.dirname` or `__dirname`.
    * */
   tsconfigRootDir: string;
+  /**
+   * List of TypeScript configuration files.
+   * Required if there are multiple files with references.
+   * */
+  tsConfigsDirs?: string[];
 };
 
-export const getEslintConfig = ({ tsconfigRootDir }: EslintConfigParams) =>
+export const getEslintConfig = ({
+  tsconfigRootDir,
+  tsConfigsDirs = [],
+}: EslintConfigParams) =>
   tseslint.config(
     {
       ignores: ["dist", "docs", "out", "coverage"],
@@ -33,7 +41,9 @@ export const getEslintConfig = ({ tsconfigRootDir }: EslintConfigParams) =>
     eslint.configs.recommended,
     {
       settings: {
-        "import/resolver": { typescript: { project: ["./tsconfig.json"] } },
+        "import/resolver": {
+          typescript: { project: ["./tsconfig.json", ...tsConfigsDirs] },
+        },
       },
     },
     {


### PR DESCRIPTION
# Add `tsConfigsDirs` param

## :recycle: Current situation & Problem
If codebases uses tsconfig's [references](https://www.typescriptlang.org/docs/handbook/project-references.html), it might require multiple tsconfig inputs. 


## :gear: Release Notes 
* Add `tsConfigsDirs` param


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
