### PR TITLE
Support special files if placed deeper than root

### DIFF
--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -48,10 +48,10 @@ export const getEslintConfig = ({
     },
     {
       files: [
-        "eslint.config.?(c)js",
-        ".prettierrc.?(c)js",
-        "postcss.config.?(c)js",
-        "tailwind.config.?(c)js",
+        "**/eslint.config.?(c)js",
+        "**/.prettierrc.?(c)js",
+        "**/postcss.config.?(c)js",
+        "**/tailwind.config.?(c)js",
       ],
       languageOptions: {
         globals: globals.node,
@@ -164,12 +164,12 @@ export const getEslintConfig = ({
     eslintPluginPrettierRecommended,
     {
       files: [
-        "playwright.config.ts",
-        "tailwind.config.ts",
-        "vite.config.ts",
-        "{app,pages}/**/*.ts?(x)",
+        "{app,pages}/**/*.ts?(x)", // app or pages directories for Next codebases
+        "**/playwright.config.ts",
+        "**/tailwind.config.ts",
+        "**/vite.config.ts",
         "**/*.stories.ts?(x)",
-        ".storybook/**/*.ts?(x)",
+        "**/.storybook/**/*.ts?(x)",
       ],
       rules: {
         "import/no-default-export": "off",


### PR DESCRIPTION
# Support special files if placed deeper than root

## :recycle: Current situation & Problem
Sometimes, special files like Tailwind config, ESLint config or Playwright config might not be placed in the root of file directory. This change enables ESLint to handle that. 


## :gear: Release Notes 
* Support special files if placed not in the root


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
