### PR TITLE
Add prefer-arrow-function rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": "22"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
         "eslint": "^9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "eslint-config-prettier": "^10",
         "eslint-import-resolver-typescript": "^3.7.0",
         "eslint-plugin-import": "^2",
+        "eslint-plugin-prefer-arrow-functions": "^3.6.2",
         "eslint-plugin-prettier": "^5",
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.18",
@@ -3646,6 +3647,142 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-prefer-arrow-functions": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow-functions/-/eslint-plugin-prefer-arrow-functions-3.6.2.tgz",
+      "integrity": "sha512-rSgMW1GFRXacz4FoLV+y56QoDj+pQOtpikaFL2OzEpoDK4umMMG4ONd9W59NLqSjstRqHjefrxco5KRkqxAe9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/utils": "8.19.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.17.0"
+      }
+    },
+    "node_modules/eslint-plugin-prefer-arrow-functions/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.19.1.tgz",
+      "integrity": "sha512-60L9KIuN/xgmsINzonOcMDSB8p82h95hoBfSBtXuO4jlR1R9L1xSkmVZKgCPVfavDlXihh4ARNjXhh1gGnLC7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/visitor-keys": "8.19.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-prefer-arrow-functions/node_modules/@typescript-eslint/types": {
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.19.1.tgz",
+      "integrity": "sha512-JBVHMLj7B1K1v1051ZaMMgLW4Q/jre5qGK0Ew6UgXz1Rqh+/xPzV1aW581OM00X6iOfyr1be+QyW8LOUf19BbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-prefer-arrow-functions/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.1.tgz",
+      "integrity": "sha512-jk/TZwSMJlxlNnqhy0Eod1PNEvCkpY6MXOXE/WLlblZ6ibb32i2We4uByoKPv1d0OD2xebDv4hbs3fm11SMw8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/visitor-keys": "8.19.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.8.0"
+      }
+    },
+    "node_modules/eslint-plugin-prefer-arrow-functions/node_modules/@typescript-eslint/utils": {
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.19.1.tgz",
+      "integrity": "sha512-IxG5gLO0Ne+KaUc8iW1A+XuKLd63o4wlbI1Zp692n1xojCl/THvgIKXJXBZixTh5dd5+yTJ/VXH7GJaaw21qXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.19.1",
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/typescript-estree": "8.19.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
+      }
+    },
+    "node_modules/eslint-plugin-prefer-arrow-functions/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.1.tgz",
+      "integrity": "sha512-fzmjU8CHK853V/avYZAvuVut3ZTfwN5YtMaoi+X9Y9MA9keaWNHC3zEQ9zvyX/7Hj+5JkNyK1l7TOR2hevHB6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.19.1",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-prefer-arrow-functions/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prefer-arrow-functions/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-config-prettier": "^10",
     "eslint-import-resolver-typescript": "^3.7.0",
     "eslint-plugin-import": "^2",
+    "eslint-plugin-prefer-arrow-functions": "^3.6.2",
     "eslint-plugin-prettier": "^5",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.18",
@@ -44,8 +45,8 @@
     "typescript-eslint": "^8.22.0"
   },
   "peerDependencies": {
-    "prettier": "^3",
-    "eslint": "^9"
+    "eslint": "^9",
+    "prettier": "^3"
   },
   "engines": {
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -53,7 +54,7 @@
   "devDependencies": {
     "@parcel/packager-ts": "^2.13.3",
     "@parcel/transformer-typescript-types": "^2.13.3",
-    "typescript": "^5.7.3",
-    "parcel": "^2.13.3"
+    "parcel": "^2.13.3",
+    "typescript": "^5.7.3"
   }
 }

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -10,6 +10,8 @@ import globals from "globals";
 // @ts-ignore
 import reactHooks from "eslint-plugin-react-hooks";
 import tseslint from "typescript-eslint";
+// @ts-ignore
+import * as preferArrow from "eslint-plugin-prefer-arrow-functions";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
 // require is necessary to prevent Parcel from treating it as ESM
 // @ts-ignore
@@ -73,6 +75,7 @@ export const getEslintConfig = ({
       },
       plugins: {
         "react-hooks": reactHooks,
+        "prefer-arrow-functions": preferArrow,
       },
       rules: {
         "import/order": [
@@ -159,6 +162,18 @@ export const getEslintConfig = ({
         "react/no-unescaped-entities": "off",
         // notFound in Tanstack Router is thrown
         "@typescript-eslint/only-throw-error": "off",
+        "prefer-arrow-functions/prefer-arrow-functions": [
+          "warn",
+          {
+            allowedNames: [],
+            allowNamedFunctions: false,
+            allowObjectProperties: false,
+            classPropertiesAllowed: false,
+            disallowPrototype: false,
+            returnStyle: "unchanged",
+            singleReturnOnly: false,
+          },
+        ],
       },
     },
     eslintPluginPrettierRecommended,

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -167,7 +167,7 @@ export const getEslintConfig = ({
           {
             allowedNames: [],
             allowNamedFunctions: false,
-            allowObjectProperties: false,
+            allowObjectProperties: true,
             classPropertiesAllowed: false,
             disallowPrototype: false,
             returnStyle: "unchanged",


### PR DESCRIPTION
# Add prefer-arrow-function rule

## :recycle: Current situation & Problem
There are arrow and plain functions in JavaScript. To keep consistency across the codes, we want to enforce usage of one type. This is opinionated, but I believe arrow functions are cleaner. 


## :gear: Release Notes 
* Add prefer-arrow-function rule


## :white_check_mark: Testing
I tested it against RadGPT codebase locally. 


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
