### PR TITLE
Split ESLint config into smaller parts, improving documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,24 +7,24 @@
       "name": "@stanfordspezi/spezi-web-configurations",
       "license": "MIT",
       "dependencies": {
-        "@eslint/js": "^9.19.0",
+        "@eslint/js": "^9.22.0",
         "eslint-config-prettier": "^10",
-        "eslint-import-resolver-typescript": "^3.7.0",
+        "eslint-import-resolver-typescript": "^4.2.1",
         "eslint-plugin-import": "^2",
         "eslint-plugin-prefer-arrow-functions": "^3.6.2",
         "eslint-plugin-prettier": "^5",
         "eslint-plugin-react": "^7.37.4",
-        "eslint-plugin-react-hooks": "^5.1.0",
-        "eslint-plugin-react-refresh": "^0.4.18",
-        "globals": "^15.14.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-refresh": "^0.4.19",
+        "globals": "^16.0.0",
         "prettier-plugin-tailwindcss": "^0.6.11",
-        "typescript-eslint": "^8.22.0"
+        "typescript-eslint": "^8.26.1"
       },
       "devDependencies": {
-        "@parcel/packager-ts": "^2.13.3",
-        "@parcel/transformer-typescript-types": "^2.13.3",
-        "parcel": "^2.13.3",
-        "typescript": "^5.7.3"
+        "@parcel/packager-ts": "^2.14.0",
+        "@parcel/transformer-typescript-types": "^2.14.0",
+        "parcel": "^2.14.0",
+        "typescript": "^5.8.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -57,6 +57,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
+      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.1.tgz",
+      "integrity": "sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -164,9 +195,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
-      "integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
+      "version": "9.22.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.22.0.tgz",
+      "integrity": "sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -462,6 +493,18 @@
         "win32"
       ]
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.7.tgz",
+      "integrity": "sha512-5yximcFK5FNompXfJFoWanu5l8v1hNGqNHh9du1xETp9HWk/B/PzvchX55WYOPaIeNglG8++68AAiauBAtbnzw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.3.1",
+        "@emnapi/runtime": "^1.3.1",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -497,32 +540,23 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@nolyfill/is-core-module": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
-      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.4.0"
-      }
-    },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.13.3.tgz",
-      "integrity": "sha512-mOuWeth0bZzRv1b9Lrvydis/hAzJyePy0gwa0tix3/zyYBvw0JY+xkXVR4qKyD/blc1Ra2qOlfI2uD3ucnsdXA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.14.0.tgz",
+      "integrity": "sha512-MRPPFCoKm0/aUTJWR/22qiKEmn/D+8iJw7ex3jlSJQ613YktL3bhkB4BO8/BCDte0Jp65/rU6QfVQ8UZi8/gNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/graph": "3.3.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/graph": "3.4.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/rust": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -530,15 +564,15 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.13.3.tgz",
-      "integrity": "sha512-Vz5+K5uCt9mcuQAMDo0JdbPYDmVdB8Nvu/A2vTEK2rqZPxvoOTczKeMBA4JqzKqGURHPRLaJCvuR8nDG+jhK9A==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.14.0.tgz",
+      "integrity": "sha512-XkkEwCZ9W6BercNQ8JMgxJJnzSBhp9u8H1EKd91C14B83fpO8SOd8Y8lJ0BKhljVU+qwZjKnyxHa4Tx+vzFbfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/fs": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/fs": "2.14.0",
+        "@parcel/logger": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "lmdb": "2.8.5"
       },
       "engines": {
@@ -549,13 +583,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.0"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.13.3.tgz",
-      "integrity": "sha512-L/PQf+PT0xM8k9nc0B+PxxOYO2phQYnbuifu9o4pFRiqVmCtHztP+XMIvRJ2gOEXy3pgAImSPFVJ3xGxMFky4g==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.14.0.tgz",
+      "integrity": "sha512-WLG6d/6Pm7zk6V+DmOLTE/T9g1kfsmTZTVfPGJwRIF29ZRKGBLNX/FZvlHEg0g7gZtRHNHF/NGu9EMlJhTRasQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -570,17 +604,17 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.13.3.tgz",
-      "integrity": "sha512-C6vjDlgTLjYc358i7LA/dqcL0XDQZ1IHXFw6hBaHHOfxPKW2T4bzUI6RURyToEK9Q1X7+ggDKqgdLxwp4veCFg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.14.0.tgz",
+      "integrity": "sha512-6zjYgB5t0jTlp+h4BTJ3aouLEGmwD2NaE2GAD/vC0owfEy2c5syPTrp5KuZ3vBx6X9hukJFPXtb6kmxdp0Vbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -588,75 +622,76 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.13.3.tgz",
-      "integrity": "sha512-WUsx83ic8DgLwwnL1Bua4lRgQqYjxiTT+DBxESGk1paNm1juWzyfPXEQDLXwiCTcWMQGiXQFQ8OuSISauVQ8dQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.14.0.tgz",
+      "integrity": "sha512-ubFryF45Xnm93Msu9IzxaEytkqBzJV/uMMwn5Z26h+MlIpRNFiRHI3M27l/9cr/GRhd6TtmdjfyEEXbIauGGiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/bundler-default": "2.13.3",
-        "@parcel/compressor-raw": "2.13.3",
-        "@parcel/namer-default": "2.13.3",
-        "@parcel/optimizer-css": "2.13.3",
-        "@parcel/optimizer-htmlnano": "2.13.3",
-        "@parcel/optimizer-image": "2.13.3",
-        "@parcel/optimizer-svgo": "2.13.3",
-        "@parcel/optimizer-swc": "2.13.3",
-        "@parcel/packager-css": "2.13.3",
-        "@parcel/packager-html": "2.13.3",
-        "@parcel/packager-js": "2.13.3",
-        "@parcel/packager-raw": "2.13.3",
-        "@parcel/packager-svg": "2.13.3",
-        "@parcel/packager-wasm": "2.13.3",
-        "@parcel/reporter-dev-server": "2.13.3",
-        "@parcel/resolver-default": "2.13.3",
-        "@parcel/runtime-browser-hmr": "2.13.3",
-        "@parcel/runtime-js": "2.13.3",
-        "@parcel/runtime-react-refresh": "2.13.3",
-        "@parcel/runtime-service-worker": "2.13.3",
-        "@parcel/transformer-babel": "2.13.3",
-        "@parcel/transformer-css": "2.13.3",
-        "@parcel/transformer-html": "2.13.3",
-        "@parcel/transformer-image": "2.13.3",
-        "@parcel/transformer-js": "2.13.3",
-        "@parcel/transformer-json": "2.13.3",
-        "@parcel/transformer-postcss": "2.13.3",
-        "@parcel/transformer-posthtml": "2.13.3",
-        "@parcel/transformer-raw": "2.13.3",
-        "@parcel/transformer-react-refresh-wrap": "2.13.3",
-        "@parcel/transformer-svg": "2.13.3"
+        "@parcel/bundler-default": "2.14.0",
+        "@parcel/compressor-raw": "2.14.0",
+        "@parcel/namer-default": "2.14.0",
+        "@parcel/optimizer-css": "2.14.0",
+        "@parcel/optimizer-htmlnano": "2.14.0",
+        "@parcel/optimizer-image": "2.14.0",
+        "@parcel/optimizer-svgo": "2.14.0",
+        "@parcel/optimizer-swc": "2.14.0",
+        "@parcel/packager-css": "2.14.0",
+        "@parcel/packager-html": "2.14.0",
+        "@parcel/packager-js": "2.14.0",
+        "@parcel/packager-raw": "2.14.0",
+        "@parcel/packager-svg": "2.14.0",
+        "@parcel/packager-wasm": "2.14.0",
+        "@parcel/reporter-dev-server": "2.14.0",
+        "@parcel/resolver-default": "2.14.0",
+        "@parcel/runtime-browser-hmr": "2.14.0",
+        "@parcel/runtime-js": "2.14.0",
+        "@parcel/runtime-rsc": "2.14.0",
+        "@parcel/runtime-service-worker": "2.14.0",
+        "@parcel/transformer-babel": "2.14.0",
+        "@parcel/transformer-css": "2.14.0",
+        "@parcel/transformer-html": "2.14.0",
+        "@parcel/transformer-image": "2.14.0",
+        "@parcel/transformer-js": "2.14.0",
+        "@parcel/transformer-json": "2.14.0",
+        "@parcel/transformer-node": "2.14.0",
+        "@parcel/transformer-postcss": "2.14.0",
+        "@parcel/transformer-posthtml": "2.14.0",
+        "@parcel/transformer-raw": "2.14.0",
+        "@parcel/transformer-react-refresh-wrap": "2.14.0",
+        "@parcel/transformer-svg": "2.14.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.0"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.13.3.tgz",
-      "integrity": "sha512-SRZFtqGiaKHlZ2YAvf+NHvBFWS3GnkBvJMfOJM7kxJRK3M1bhbwJa/GgSdzqro5UVf9Bfj6E+pkdrRQIOZ7jMQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.14.0.tgz",
+      "integrity": "sha512-pcmDq/cCla9Umoqxmy9VxAZ9fWh5H0u12PSGEesyLZbiECVkN+jgo9PPnBr7gwWVc1K71pGo4e5C5QpyGcyHJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.13.3",
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/events": "2.13.3",
-        "@parcel/feature-flags": "2.13.3",
-        "@parcel/fs": "2.13.3",
-        "@parcel/graph": "3.3.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/package-manager": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/profiler": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/cache": "2.14.0",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/events": "2.14.0",
+        "@parcel/feature-flags": "2.14.0",
+        "@parcel/fs": "2.14.0",
+        "@parcel/graph": "3.4.0",
+        "@parcel/logger": "2.14.0",
+        "@parcel/package-manager": "2.14.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/profiler": "2.14.0",
+        "@parcel/rust": "2.14.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3",
+        "@parcel/types": "2.14.0",
+        "@parcel/utils": "2.14.0",
+        "@parcel/workers": "2.14.0",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
         "clone": "^2.1.1",
@@ -676,9 +711,9 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.13.3.tgz",
-      "integrity": "sha512-C70KXLBaXLJvr7XCEVu8m6TqNdw1gQLxqg5BQ8roR62R4vWWDnOq8PEksxDi4Y8Z/FF4i3Sapv6tRx9iBNxDEg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.14.0.tgz",
+      "integrity": "sha512-Y7sLbpWIeNqMgtB+RIcvFia6QKYCckz7CO0sSsYi9A76HQDO+poSPXAdzWZbkZbfQCeKwKbLGEpbPLfEpTXiqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -693,10 +728,24 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/error-overlay": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/error-overlay/-/error-overlay-2.14.0.tgz",
+      "integrity": "sha512-Uh6rTPChbM5/1l9PpWSWep5TbOBiHeQN4Ab2M2MEqCsVl663laYdkiL1k2foPhv7Njr8MMMf5mbT5UiT8HsLlg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/events": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.13.3.tgz",
-      "integrity": "sha512-ZkSHTTbD/E+53AjUzhAWTnMLnxLEU5yRw0H614CaruGh+GjgOIKyukGeToF5Gf/lvZ159VrJCGE0Z5EpgHVkuQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.14.0.tgz",
+      "integrity": "sha512-qkO4fWnFTjp0CP5U5H7kOJ2dluNcJJ+N94lIHRmtxV2wtQi9SeLLcDIklCekRrhKaCF6QXeXUet5ANso61FVrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -708,9 +757,9 @@
       }
     },
     "node_modules/@parcel/feature-flags": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.13.3.tgz",
-      "integrity": "sha512-UZm14QpamDFoUut9YtCZSpG1HxPs07lUwUCpsAYL0PpxASD3oWJQxIJGfDZPa2272DarXDG9adTKrNXvkHZblw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.14.0.tgz",
+      "integrity": "sha512-SzoIz7SjwVmS2BIUJeDM/me1rYaZzN1uLrr8KHvoJldTO484gQzlnRhN+pk5BTaHW5Jrg8oob2LQWBv9kymphg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -722,18 +771,18 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.13.3.tgz",
-      "integrity": "sha512-+MPWAt0zr+TCDSlj1LvkORTjfB/BSffsE99A9AvScKytDSYYpY2s0t4vtV9unSh0FHMS2aBCZNJ4t7KL+DcPIg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.14.0.tgz",
+      "integrity": "sha512-r10003gyxvW1Qn/LTiNS2oCNPv22nLUW7dJIEEZb/0v8UNbzrZhVB7s+iBok2CNBg3AFPMi6W10jqnvkjOBB9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/feature-flags": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/types-internal": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/feature-flags": "2.14.0",
+        "@parcel/rust": "2.14.0",
+        "@parcel/types-internal": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.13.3"
+        "@parcel/workers": "2.14.0"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -743,17 +792,17 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.0"
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.3.3.tgz",
-      "integrity": "sha512-pxs4GauEdvCN8nRd6wG3st6LvpHske3GfqGwUSR0P0X0pBPI1/NicvXz6xzp3rgb9gPWfbKXeI/2IOTfIxxVfg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.4.0.tgz",
+      "integrity": "sha512-S9kVoFmh9jlMO8XJS2Br4fW/hhLc1mKXSXKMrIQe5dqf7z9l3a0sl+dY9KJ0KFuiYKOxqhgWCuqj/nMvD+CZrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/feature-flags": "2.13.3",
+        "@parcel/feature-flags": "2.14.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -765,14 +814,14 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.13.3.tgz",
-      "integrity": "sha512-8YF/ZhsQgd7ohQ2vEqcMD1Ag9JlJULROWRPGgGYLGD+twuxAiSdiFBpN3f+j4gQN4PYaLaIS/SwUFx11J243fQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.14.0.tgz",
+      "integrity": "sha512-dtWVz8oKVOpW1s013wDH8G2C8sv8ZuJ2JgTJHMV4sPPfX0KMHx04x0L8+JMmmo4mvjtrAy/lTKXh/yq2tvZnbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/events": "2.13.3"
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/events": "2.14.0"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -783,9 +832,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.13.3.tgz",
-      "integrity": "sha512-B4rUdlNUulJs2xOQuDbN7Hq5a9roq8IZUcJ1vQ8PAv+zMGb7KCfqIIr/BSCDYGhayfAGBVWW8x55Kvrl1zrDYw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.14.0.tgz",
+      "integrity": "sha512-6HlvNAwyBtbyI0A5BnU51Y+4gJEra7p8gKemCw5zU4cph4I822jkurAedQ6ffrDK7vFRSXBvY1Ab524rN9BfEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -800,19 +849,19 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.13.3.tgz",
-      "integrity": "sha512-A2a5A5fuyNcjSGOS0hPcdQmOE2kszZnLIXof7UMGNkNkeC62KAG8WcFZH5RNOY3LT5H773hq51zmc2Y2gE5Rnw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.14.0.tgz",
+      "integrity": "sha512-jlKfS1k/xOwI5FyZB4Tw3J4clFj2RTjn/ZKgjNSfvjSMoAn05SOL9MJ1Po7p7b4W/FKV4fWgvh5UchRX8hasZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -820,17 +869,17 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.4.3.tgz",
-      "integrity": "sha512-IEnMks49egEic1ITBp59VQyHzkSQUXqpU9hOHwqN3KoSTdZ6rEgrXcS3pa6tdXay4NYGlcZ88kFCE8i/xYoVCg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.5.0.tgz",
+      "integrity": "sha512-c6yWNh24k8F5+rgp1ekCKJ5Ftb8D4kl+1CzuWr6Yghcg+0hytwhNORrUsH4cp9yI/st13FcHUZTzRlllF47RQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/fs": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/fs": "2.14.0",
+        "@parcel/rust": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "nullthrows": "^1.1.1",
         "semver": "^7.5.2"
       },
@@ -843,23 +892,23 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.13.3.tgz",
-      "integrity": "sha512-A8o9IVCv919vhv69SkLmyW2WjJR5WZgcMqV6L1uiGF8i8z18myrMhrp2JuSHx29PRT9uNyzNC4Xrd4StYjIhJg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.14.0.tgz",
+      "integrity": "sha512-Z0n8zKalRJyZWk0Td3Ki+73+RVnRr8TLdRguEgSmAF4Dqh14267OSkZBm9GwPb7MgVRCy/XS5xw4YGTZmdrDyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
+        "@parcel/utils": "2.14.0",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -867,22 +916,22 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.13.3.tgz",
-      "integrity": "sha512-K4Uvg0Sy2pECP7pdvvbud++F0pfcbNkq+IxTrgqBX5HJnLEmRZwgdvZEKF43oMEolclMnURMQRGjRplRaPdbXg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.14.0.tgz",
+      "integrity": "sha512-/VwHAxNF+9aLB8ehzL2rv6hKpOMQhYPU0KjTeBflgAWQMXAtdQknjBCXvzlXDc9hDJAewzQIRCUEg4MM6ZeKWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -890,44 +939,44 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.13.3.tgz",
-      "integrity": "sha512-wlDUICA29J4UnqkKrWiyt68g1e85qfYhp4zJFcFJL0LX1qqh1QwsLUz3YJ+KlruoqPxJSFEC8ncBEKiVCsqhEQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.14.0.tgz",
+      "integrity": "sha512-XAwStyaLwUFUC8z/jrOXKTVGiVMZlokPI9A1yEJlnnXaI8SeARztVHz5ZBzLasSfOwBQCZqSukT+ZWTi/oJoGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3"
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/rust": "2.14.0",
+        "@parcel/utils": "2.14.0",
+        "@parcel/workers": "2.14.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.0"
       }
     },
     "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.13.3.tgz",
-      "integrity": "sha512-piIKxQKzhZK54dJR6yqIcq+urZmpsfgUpLCZT3cnWlX4ux5+S2iN66qqZBs0zVn+a58LcWcoP4Z9ieiJmpiu2w==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.14.0.tgz",
+      "integrity": "sha512-EREtUqfqlvNTaNoO8AqhLYlyU65nhymgoCVPsLntb8azuUJfpBKN/AOTAV9bqLdsfeQal40d30T9OekO+sVUXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3"
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/utils": "2.14.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -935,22 +984,22 @@
       }
     },
     "node_modules/@parcel/optimizer-swc": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.13.3.tgz",
-      "integrity": "sha512-zNSq6oWqLlW8ksPIDjM0VgrK6ZAJbPQCDvs1V+p0oX3CzEe85lT5VkRpnfrN1+/vvEJNGL8e60efHKpI+rXGTA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.14.0.tgz",
+      "integrity": "sha512-IfwdEFlDw4uhuSNTtBLSfpoX0pYTz+QlofIQwkwqeBUdOJuPATPAM5c7UKNAlhON68rWuFkeprgLPKEFKGLqUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
-        "@swc/core": "^1.7.26",
+        "@parcel/utils": "2.14.0",
+        "@swc/core": "^1.11.5",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -958,20 +1007,20 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.13.3.tgz",
-      "integrity": "sha512-FLNI5OrZxymGf/Yln0E/kjnGn5sdkQAxW7pQVdtuM+5VeN75yibJRjsSGv88PvJ+KvpD2ANgiIJo1RufmoPcww==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.14.0.tgz",
+      "integrity": "sha512-raaAD51TrE1leeAL/FmonEEr9srpOo/1rvMf855iHfmArdARRDXAS8eh90G5+KrrxtC8O1fTxjdZJ98xAiKFUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/fs": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/node-resolver-core": "3.4.3",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3",
-        "@swc/core": "^1.7.26",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/fs": "2.14.0",
+        "@parcel/logger": "2.14.0",
+        "@parcel/node-resolver-core": "3.5.0",
+        "@parcel/types": "2.14.0",
+        "@parcel/utils": "2.14.0",
+        "@parcel/workers": "2.14.0",
+        "@swc/core": "^1.11.5",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -982,26 +1031,26 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.0"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.13.3.tgz",
-      "integrity": "sha512-ghDqRMtrUwaDERzFm9le0uz2PTeqqsjsW0ihQSZPSAptElRl9o5BR+XtMPv3r7Ui0evo+w35gD55oQCJ28vCig==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.14.0.tgz",
+      "integrity": "sha512-5LbVo/mNFbCnD5kZegCQdLRJQqElJjBc5xzQs6ZZXoTpSEBZKGJkkIckK634ARgVgIt3CTCAB90DD3PPOwi58g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
+        "@parcel/utils": "2.14.0",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1009,21 +1058,21 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.13.3.tgz",
-      "integrity": "sha512-jDLnKSA/EzVEZ3/aegXO3QJ/Ij732AgBBkIQfeC8tUoxwVz5b3HiPBAjVjcUSfZs7mdBSHO+ELWC3UD+HbsIrQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.14.0.tgz",
+      "integrity": "sha512-ln6kbAZpo+Q+JNIZ55H/aBc66uBV/8021YttS61/DoW35he/XmMOBPziNce9obDHYzyQSJPx+6ACSg6zebkE/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/types": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1031,24 +1080,24 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.13.3.tgz",
-      "integrity": "sha512-0pMHHf2zOn7EOJe88QJw5h/wcV1bFfj6cXVcE55Wa8GX3V+SdCgolnlvNuBcRQ1Tlx0Xkpo+9hMFVIQbNQY6zw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.14.0.tgz",
+      "integrity": "sha512-gYqXIZNglwQCdkzcMM5KpKYApGCnZsV9+AM467IwAR073xDXWUJjJ28CKSXXCfickgB0VwRPivn2x/DhfCUKAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/rust": "2.14.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/types": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1072,17 +1121,17 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.13.3.tgz",
-      "integrity": "sha512-AWu4UB+akBdskzvT3KGVHIdacU9f7cI678DQQ1jKQuc9yZz5D0VFt3ocFBOmvDfEQDF0uH3jjtJR7fnuvX7Biw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.14.0.tgz",
+      "integrity": "sha512-FShIKhExsfTNjKXJ73yKc7C4yk2cKZe2scaiVnDTUoPVaXeoU/OKOSixbI0krUrGh7KwEZ1pEJvXrEp7B+Sf/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1090,20 +1139,20 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.13.3.tgz",
-      "integrity": "sha512-tKGRiFq/4jh5u2xpTstNQ7gu+RuZWzlWqpw5NaFmcKe6VQe5CMcS499xTFoREAGnRvevSeIgC38X1a+VOo+/AA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.14.0.tgz",
+      "integrity": "sha512-ee7lbAg0rpjIKLEYM/hKgG8xt0P3ZWNfQb3QDnw3yIdp0kDADQbiswyKJEUDslBE4+Y4HxonSN48zK3UKleYGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/types": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "posthtml": "^0.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1111,17 +1160,17 @@
       }
     },
     "node_modules/@parcel/packager-ts": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.13.3.tgz",
-      "integrity": "sha512-z7GcPe2V2dScOw+rVUmtsurkCiWCiy61/jCjKuX21HezDhK/+zta95wht2SbUSlrPgwK+/TWbb+9laDFHklWgA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.14.0.tgz",
+      "integrity": "sha512-XaO17awCGyuyiAgyT72f6MgBeqVtsBgA8bZ++6LoTU7PJYZQ17uNzwnQnZvaUwsLQaazcGau8oITCmxlE5/mjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1129,17 +1178,17 @@
       }
     },
     "node_modules/@parcel/packager-wasm": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.13.3.tgz",
-      "integrity": "sha512-SZB56/b230vFrSehVXaUAWjJmWYc89gzb8OTLkBm7uvtFtov2J1R8Ig9TTJwinyXE3h84MCFP/YpQElSfoLkJw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.14.0.tgz",
+      "integrity": "sha512-OydfRDqJCeHVsblcPC11yUn2mrDzkp4HrD1QO2CT89nQbLvUFGKHDsP2VaXAAvuSRLFB46Dqa5ocCNdAHC8DZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.0"
       },
       "engines": {
         "node": ">=16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1147,13 +1196,13 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.13.3.tgz",
-      "integrity": "sha512-cterKHHcwg6q11Gpif/aqvHo056TR+yDVJ3fSdiG2xr5KD1VZ2B3hmofWERNNwjMcnR1h9Xq40B7jCKUhOyNFA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.14.0.tgz",
+      "integrity": "sha512-vlrxyErfpGcMyaEADi4EYCmV8T5RsiyhtzZKwUiLwNzfXTV0oICNzOAmVUoE42pcY70XtH1f/TWdN9dOKd3LQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/types": "2.13.3"
+        "@parcel/types": "2.14.0"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -1164,15 +1213,15 @@
       }
     },
     "node_modules/@parcel/profiler": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.13.3.tgz",
-      "integrity": "sha512-ok6BwWSLvyHe5TuSXjSacYnDStFgP5Y30tA9mbtWSm0INDsYf+m5DqzpYPx8U54OaywWMK8w3MXUClosJX3aPA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.14.0.tgz",
+      "integrity": "sha512-iRldBix80/zq1HWkGP3xAyN73n9i40oxNso3C4spx3xw+iQdJ3/+UG+tJXk21IZhjLx6Gze2fu/Mqgr3egxndw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/events": "2.13.3",
-        "@parcel/types-internal": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/events": "2.14.0",
+        "@parcel/types-internal": "2.14.0",
         "chrome-trace-event": "^1.0.2"
       },
       "engines": {
@@ -1184,21 +1233,21 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.13.3.tgz",
-      "integrity": "sha512-EA5tKt/6bXYNMEavSs35qHlFdx6cZmRazlZxPBgxPePQYoouNAPMNLUOEQozaPhz9f5fvNDN7EHOFaAWcdO2LA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.14.0.tgz",
+      "integrity": "sha512-WMrzOb7ZAuCWm7TR5gZ9Ey+TAXdlFcJVu4DjNK7AB8zIG8U6vYr0//JWRuduMGSbDSiKvLa7+9MVobwughkk0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/types": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "chalk": "^4.1.2",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1206,18 +1255,20 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.13.3.tgz",
-      "integrity": "sha512-ZNeFp6AOIQFv7mZIv2P5O188dnZHNg0ymeDVcakfZomwhpSva2dFNS3AnvWo4eyWBlUxkmQO8BtaxeWTs7jAuA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.14.0.tgz",
+      "integrity": "sha512-qBcvF6602xgO1mXr5TZcz+a3332PqaF/W/NV4Be/XEnp+eUdIhMXN2sFKhB5X7suSIeDrSzowB5KGACwzW5wVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3"
+        "@parcel/codeframe": "2.14.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.14.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1225,20 +1276,20 @@
       }
     },
     "node_modules/@parcel/reporter-tracer": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.13.3.tgz",
-      "integrity": "sha512-aBsVPI8jLZTDkFYrI69GxnsdvZKEYerkPsu935LcX9rfUYssOnmmUP+3oI+8fbg+qNjJuk9BgoQ4hCp9FOphMQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.14.0.tgz",
+      "integrity": "sha512-aSkkADkfKL5BRcgZ1ZNE/RIGcSD+YG57g61DfPYQdWQNwAjdusAtXH/94X5OkyylF2tfa1pdkXy934W/auoalQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1246,18 +1297,18 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.13.3.tgz",
-      "integrity": "sha512-urBZuRALWT9pFMeWQ8JirchLmsQEyI9lrJptiwLbJWrwvmlwSUGkcstmPwoNRf/aAQjICB7ser/247Vny0pFxA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.14.0.tgz",
+      "integrity": "sha512-MnkWE1NUA/V5qNSAYNF2zchiGcGngoY6tBa0ZEGZ6REojpjRAPW6Udya2/O3/7sPZh9wBytEGkaC2bpCtXij9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/node-resolver-core": "3.4.3",
-        "@parcel/plugin": "2.13.3"
+        "@parcel/node-resolver-core": "3.5.0",
+        "@parcel/plugin": "2.14.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1265,18 +1316,18 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.13.3.tgz",
-      "integrity": "sha512-EAcPojQFUNUGUrDk66cu3ySPO0NXRVS5CKPd4QrxPCVVbGzde4koKu8krC/TaGsoyUqhie8HMnS70qBP0GFfcQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.14.0.tgz",
+      "integrity": "sha512-dbME8ZOvgQZSMtpTzQUinhLNxi2CJKqRKEG28TnNfsyVa0MoYLR/TN4Q2RU/SRuQyhddmUN0bSWasn9Yu+dXVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3"
+        "@parcel/plugin": "2.14.0",
+        "@parcel/utils": "2.14.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1284,41 +1335,41 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.13.3.tgz",
-      "integrity": "sha512-62OucNAnxb2Q0uyTFWW/0Hvv2DJ4b5H6neh/YFu2/wmxaZ37xTpEuEcG2do7KW54xE5DeLP+RliHLwi4NvR3ww==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.14.0.tgz",
+      "integrity": "sha512-k3+T2Rqbjg/0+3NPFVReEyu3CcjLHZWWmcDyAwuoRJb8H3XVfUbrTB18svN8Y99Rq+x+DEX3gLzsW++v/POSUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.13.3.tgz",
-      "integrity": "sha512-PYZ1klpJVwqE3WuifILjtF1dugtesHEuJcXYZI85T6UoRSD5ctS1nAIpZzT14Ga1lRt/jd+eAmhWL1l3m/Vk1Q==",
+    "node_modules/@parcel/runtime-rsc": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-rsc/-/runtime-rsc-2.14.0.tgz",
+      "integrity": "sha512-BsvO5N0e8sprXA+LoJGeQkegH0oZ55Dlg+5Nx5lkTV920Ucei1IuwaUydcYBVgWbFt+o337CJP8Qbv5/7+yLtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "react-error-overlay": "6.0.9",
-        "react-refresh": ">=0.9 <=0.14"
+        "@parcel/plugin": "2.14.0",
+        "@parcel/rust": "2.14.0",
+        "@parcel/utils": "2.14.0",
+        "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "node": ">= 12.0.0",
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1326,19 +1377,19 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.13.3.tgz",
-      "integrity": "sha512-BjMhPuT7Us1+YIo31exPRwomPiL+jrZZS5UUAwlEW2XGHDceEotzRM94LwxeFliCScT4IOokGoxixm19qRuzWg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.14.0.tgz",
+      "integrity": "sha512-WuYrpjoE6DPl6oWaSf3W3sgTa7JiSZ7fosQE89HxNC4rLaeOMjfBiOazhcVoi5qfAJwitIoONJD1IaO3qwP3AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1346,9 +1397,9 @@
       }
     },
     "node_modules/@parcel/rust": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.13.3.tgz",
-      "integrity": "sha512-dLq85xDAtzr3P5200cvxk+8WXSWauYbxuev9LCPdwfhlaWo/JEj6cu9seVdWlkagjGwkoV1kXC+GGntgUXOLAQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.14.0.tgz",
+      "integrity": "sha512-KIyUxZCLFkyqTn5NXDwXJidT0IZRb1f4kQRLPNfvObW1bwpZmNF9pSXr1rzRAfBvWtF9C/VFLc37AzcVKDti9Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1357,6 +1408,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "napi-wasm": "^1.1.2"
+      },
+      "peerDependenciesMeta": {
+        "napi-wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@parcel/source-map": {
@@ -1373,16 +1432,16 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.13.3.tgz",
-      "integrity": "sha512-ikzK9f5WTFrdQsPitQgjCPH6HmVU8AQPRemIJ2BndYhtodn5PQut5cnSvTrqax8RjYvheEKCQk/Zb/uR7qgS3g==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.14.0.tgz",
+      "integrity": "sha512-K0SFVLhEVd5jglwps7MGhnwXnmhT6GBHMOmrVYf+xgJs5md8QN/i5GGfnbDJZEA+YStSda8ZaWR6jfCZGZxa2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
+        "@parcel/utils": "2.14.0",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -1390,7 +1449,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1398,23 +1457,23 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.13.3.tgz",
-      "integrity": "sha512-zbrNURGph6JeVADbGydyZ7lcu/izj41kDxQ9xw4RPRW/3rofQiTU0OTREi+uBWiMENQySXVivEdzHA9cA+aLAA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.14.0.tgz",
+      "integrity": "sha512-Tsl9uDTaGL/2n+YfYc1n77D95eBVG7EE1dawUxRPPWgtM3CRb+loToLuCezDrh9qaKiX0FY4AyxdYhKXLsxYHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
+        "@parcel/utils": "2.14.0",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1422,15 +1481,15 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.13.3.tgz",
-      "integrity": "sha512-Yf74FkL9RCCB4+hxQRVMNQThH9+fZ5w0NLiQPpWUOcgDEEyxTi4FWPQgEBsKl/XK2ehdydbQB9fBgPQLuQxwPg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.14.0.tgz",
+      "integrity": "sha512-mAk9p/zxIOXMWmi7zdbDxG3YchK8HMMQ3L5l4VD41J5K3VQ/B8nnEqRRhAvtEl+nBbU1psIgcsOg+jkrevDikA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/rust": "2.14.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.12.1",
@@ -1440,7 +1499,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1461,38 +1520,38 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.13.3.tgz",
-      "integrity": "sha512-wL1CXyeFAqbp2wcEq/JD3a/tbAyVIDMTC6laQxlIwnVV7dsENhK1qRuJZuoBdixESeUpFQSmmQvDIhcfT/cUUg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.14.0.tgz",
+      "integrity": "sha512-TE/Gtz4GU+PtA/dGGbQbUGVAG/0XZwFcTZKP9kLZGnREAtMPTKfeIirum6Nn8IS/Xx5nWI52GpsmyYZXEm/T8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/utils": "2.14.0",
+        "@parcel/workers": "2.14.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.0"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.13.3.tgz",
-      "integrity": "sha512-KqfNGn1IHzDoN2aPqt4nDksgb50Xzcny777C7A7hjlQ3cmkjyJrixYjzzsPaPSGJ+kJpknh3KE8unkQ9mhFvRQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.14.0.tgz",
+      "integrity": "sha512-4acYA9uQ89Zz86+YHXk0m8Aq0FeYc4p0T8ODUiUbzofMKHhDmVKNzdIUYshCEcEdDfujdn472OmM7A4NPEfiEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/rust": "2.14.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3",
+        "@parcel/utils": "2.14.0",
+        "@parcel/workers": "2.14.0",
         "@swc/helpers": "^0.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1",
@@ -1501,29 +1560,47 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.0"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.13.3.tgz",
-      "integrity": "sha512-rrq0ab6J0w9ePtsxi0kAvpCmrUYXXAx1Z5PATZakv89rSYbHBKEdXxyCoKFui/UPVCUEGVs5r0iOFepdHpIyeA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.14.0.tgz",
+      "integrity": "sha512-QnpJmdmnR/s9K5Jvpc+PDLWvy5JSjS7EqsVEp2YQV+xoO3SpT9BWh5kuFvtMPmWQubyiJrhmgpFhohw/t3bd0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
+        "@parcel/plugin": "2.14.0",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-node": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-node/-/transformer-node-2.14.0.tgz",
+      "integrity": "sha512-AXTfC+U60AdTNsoaKBaxOdnY1B7XIqsBisdQDXzOtdb7xmYBvOVK4PmQPD7AUPVIg8uk0lmoBp9p/c1woh4rgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/plugin": "2.14.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0",
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1531,16 +1608,16 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.13.3.tgz",
-      "integrity": "sha512-AIiWpU0QSFBrPcYIqAnhqB8RGE6yHFznnxztfg1t2zMSOnK3xoU6xqYKv8H/MduShGGrC3qVOeDfM8MUwzL3cw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.14.0.tgz",
+      "integrity": "sha512-ih5SM7YB8evNe/zOPauWrh8TGIYw4qdyKrMNLiSN5mGeWkBkVWaf8bM68GeLWtOkToFxue885Mjz+aJ2M7Jyuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/rust": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -1548,7 +1625,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1556,14 +1633,14 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.13.3.tgz",
-      "integrity": "sha512-5GSLyccpHASwFAu3uJ83gDIBSvfsGdVmhJvy0Vxe+K1Fklk2ibhvvtUHMhB7mg6SPHC+R9jsNc3ZqY04ZLeGjw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.14.0.tgz",
+      "integrity": "sha512-NhE4o67rRkhW1k/IYI8RivXjuIHMBhC6gcHFT96P4LfuMerJb5YzcKPE59XmfMjH4Ndr4nQaZmVN0NgptqNiAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.12.1",
@@ -1572,7 +1649,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1580,17 +1657,17 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.13.3.tgz",
-      "integrity": "sha512-BFsAbdQF0l8/Pdb7dSLJeYcd8jgwvAUbHgMink2MNXJuRUvDl19Gns8jVokU+uraFHulJMBj40+K/RTd33in4g==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.14.0.tgz",
+      "integrity": "sha512-Q0xYqHt5uQx/Lw/w5G91RF4g3hRKN1/lmIyGOVyBvElY6pYvkTSI6wz5VoXwOc1aMpffQTWUqLqifgBy9rZ0OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1598,19 +1675,20 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.13.3.tgz",
-      "integrity": "sha512-mOof4cRyxsZRdg8kkWaFtaX98mHpxUhcGPU+nF9RQVa9q737ItxrorsPNR9hpZAyE2TtFNflNW7RoYsgvlLw8w==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.14.0.tgz",
+      "integrity": "sha512-wy2INSD4tHUSkGnIb/X0rl94X0gV23oaOBvOswUvT1EjyfRJ4em+LaZYVnoZJOqwHIFUBrUaMThy4a7jNiwSog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "react-refresh": ">=0.9 <=0.14"
+        "@parcel/error-overlay": "2.14.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/utils": "2.14.0",
+        "react-refresh": ">=0.9 <=0.16"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1618,15 +1696,15 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.13.3.tgz",
-      "integrity": "sha512-9jm7ZF4KHIrGLWlw/SFUz5KKJ20nxHvjFAmzde34R9Wu+F1BOjLZxae7w4ZRwvIc+UVOUcBBQFmhSVwVDZg6Dw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.14.0.tgz",
+      "integrity": "sha512-T9unNRjjvXwO1/wIZbxBXU0ufRsVE2bb9cJgno0314liZFybAioXLNXZ7z8/mB1YAgVcHd1HPLjE+2X7y1wRfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
+        "@parcel/rust": "2.14.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.12.1",
@@ -1635,7 +1713,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1643,22 +1721,22 @@
       }
     },
     "node_modules/@parcel/transformer-typescript-types": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.13.3.tgz",
-      "integrity": "sha512-5FRqoj2/ZH3zVc4HO/OnMA1B22kgGIRb3CfsircP3/KHj5t38IDU+s2tctrccs0EjFGyjwIEwyaeuWgqf6fq4g==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.14.0.tgz",
+      "integrity": "sha512-xw6VeJcC+vQVRlF2UoxTXdO/GUOOMr4F6kaZzULtmhuSIB4lVxD0cC/OP/9GHqRvoY3qsFZOP7X03klib/1cRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/plugin": "2.14.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/ts-utils": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/ts-utils": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1669,9 +1747,9 @@
       }
     },
     "node_modules/@parcel/ts-utils": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.13.3.tgz",
-      "integrity": "sha512-ZHPJd7yh5b8iYgyHCZ31nqXHKLGKYnxqhLlEe/zPg8EV3NAVbbiuj2905w2ED5mt5BC+AR1cOEyMuxMRMtUuSQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.14.0.tgz",
+      "integrity": "sha512-eLVH4+Qa+4hYKqMPXljM05Fx5JPgGld1jhxlB5Qm9HJHU9yf8MzNNI80M9AZcNx7jHRn5ZsTTOnG6k+oW+xQNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1689,41 +1767,41 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.13.3.tgz",
-      "integrity": "sha512-+RpFHxx8fy8/dpuehHUw/ja9PRExC3wJoIlIIF42E7SLu2SvlTHtKm6EfICZzxCXNEBzjoDbamCRcN0nmTPlhw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.14.0.tgz",
+      "integrity": "sha512-w5gqSN5FQiP9Xiv1DeCtr7Z+y3O/AhuBf38ZKQjGcxLUBFNmN2I5ulkZ2sj8xIQncYUwbYcv7TWxD/TuJJiBsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/types-internal": "2.13.3",
-        "@parcel/workers": "2.13.3"
+        "@parcel/types-internal": "2.14.0",
+        "@parcel/workers": "2.14.0"
       }
     },
     "node_modules/@parcel/types-internal": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.13.3.tgz",
-      "integrity": "sha512-Lhx0n+9RCp+Ipktf/I+CLm3zE9Iq9NtDd8b2Vr5lVWyoT8AbzBKIHIpTbhLS4kjZ80L3I6o93OYjqAaIjsqoZw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.14.0.tgz",
+      "integrity": "sha512-JffGtI9dk4P0FyxVeKdm6PCEWVW4Z/3Q0CLEaXhG67pFz4j15pdqtdzQ3Xf42HIWW+jOZ4KFtDwbtF5+n+1lwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/feature-flags": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/feature-flags": "2.14.0",
         "@parcel/source-map": "^2.1.1",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.13.3.tgz",
-      "integrity": "sha512-yxY9xw2wOUlJaScOXYZmMGoZ4Ck4Kqj+p6Koe5kLkkWM1j98Q0Dj2tf/mNvZi4yrdnlm+dclCwNRnuE8Q9D+pw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.14.0.tgz",
+      "integrity": "sha512-hiXMDS2xzS/ZHqpvcoJCR4GxGLWEqd/UGB/z5wzJ6QVouhatBtYe7Ca3vQtwc/ki9JDeNZv6+QmiVqPmQWv6dA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/codeframe": "2.13.3",
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/markdown-ansi": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/codeframe": "2.14.0",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/logger": "2.14.0",
+        "@parcel/markdown-ansi": "2.14.0",
+        "@parcel/rust": "2.14.0",
         "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.2",
         "nullthrows": "^1.1.1"
@@ -2046,17 +2124,17 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.13.3.tgz",
-      "integrity": "sha512-oAHmdniWTRwwwsKbcF4t3VjOtKN+/W17Wj5laiYB+HLkfsjGTfIQPj3sdXmrlBAGpI4omIcvR70PHHXnfdTfwA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.14.0.tgz",
+      "integrity": "sha512-kte2OzI2L3lvZsJ9iu4qRmOT5fMhm6cdCS2oeAm8iN5btljrDCbjEqz35FSwfmxudIKBlfqI+89l5pnBou1Exw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/profiler": "2.13.3",
-        "@parcel/types-internal": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/logger": "2.14.0",
+        "@parcel/profiler": "2.14.0",
+        "@parcel/types-internal": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -2067,7 +2145,7 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.0"
       }
     },
     "node_modules/@pkgr/core": {
@@ -2089,15 +2167,15 @@
       "license": "MIT"
     },
     "node_modules/@swc/core": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.11.tgz",
-      "integrity": "sha512-3zGU5y3S20cAwot9ZcsxVFNsSVaptG+dKdmAxORSE3EX7ixe1Xn5kUwLlgIsM4qrwTUWCJDLNhRS+2HLFivcDg==",
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.11.tgz",
+      "integrity": "sha512-pCVY2Wn6dV/labNvssk9b3Owi4WOYsapcbWm90XkIj4xH/56Z6gzja9fsU+4MdPuEfC2Smw835nZHcdCFGyX6A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.17"
+        "@swc/types": "^0.1.19"
       },
       "engines": {
         "node": ">=10"
@@ -2107,16 +2185,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.10.11",
-        "@swc/core-darwin-x64": "1.10.11",
-        "@swc/core-linux-arm-gnueabihf": "1.10.11",
-        "@swc/core-linux-arm64-gnu": "1.10.11",
-        "@swc/core-linux-arm64-musl": "1.10.11",
-        "@swc/core-linux-x64-gnu": "1.10.11",
-        "@swc/core-linux-x64-musl": "1.10.11",
-        "@swc/core-win32-arm64-msvc": "1.10.11",
-        "@swc/core-win32-ia32-msvc": "1.10.11",
-        "@swc/core-win32-x64-msvc": "1.10.11"
+        "@swc/core-darwin-arm64": "1.11.11",
+        "@swc/core-darwin-x64": "1.11.11",
+        "@swc/core-linux-arm-gnueabihf": "1.11.11",
+        "@swc/core-linux-arm64-gnu": "1.11.11",
+        "@swc/core-linux-arm64-musl": "1.11.11",
+        "@swc/core-linux-x64-gnu": "1.11.11",
+        "@swc/core-linux-x64-musl": "1.11.11",
+        "@swc/core-win32-arm64-msvc": "1.11.11",
+        "@swc/core-win32-ia32-msvc": "1.11.11",
+        "@swc/core-win32-x64-msvc": "1.11.11"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -2128,9 +2206,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.11.tgz",
-      "integrity": "sha512-ZpgEaNcx2e5D+Pd0yZGVbpSrEDOEubn7r2JXoNBf0O85lPjUm3HDzGRfLlV/MwxRPAkwm93eLP4l7gYnc50l3g==",
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.11.tgz",
+      "integrity": "sha512-vJcjGVDB8cZH7zyOkC0AfpFYI/7GHKG0NSsH3tpuKrmoAXJyCYspKPGid7FT53EAlWreN7+Pew+bukYf5j+Fmg==",
       "cpu": [
         "arm64"
       ],
@@ -2145,9 +2223,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.11.tgz",
-      "integrity": "sha512-szObinnq2o7spXMDU5pdunmUeLrfV67Q77rV+DyojAiGJI1RSbEQotLOk+ONOLpoapwGUxOijFG4IuX1xiwQ2g==",
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.11.tgz",
+      "integrity": "sha512-/N4dGdqEYvD48mCF3QBSycAbbQd3yoZ2YHSzYesQf8usNc2YpIhYqEH3sql02UsxTjEFOJSf1bxZABDdhbSl6A==",
       "cpu": [
         "x64"
       ],
@@ -2162,9 +2240,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.11.tgz",
-      "integrity": "sha512-tVE8aXQwd8JUB9fOGLawFJa76nrpvp3dvErjozMmWSKWqtoeO7HV83aOrVtc8G66cj4Vq7FjTE9pOJeV1FbKRw==",
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.11.tgz",
+      "integrity": "sha512-hsBhKK+wVXdN3x9MrL5GW0yT8o9GxteE5zHAI2HJjRQel3HtW7m5Nvwaq+q8rwMf4YQRd8ydbvwl4iUOZx7i2Q==",
       "cpu": [
         "arm"
       ],
@@ -2179,9 +2257,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.11.tgz",
-      "integrity": "sha512-geFkENU5GMEKO7FqHOaw9HVlpQEW10nICoM6ubFc0hXBv8dwRXU4vQbh9s/isLSFRftw1m4jEEWixAnXSw8bxQ==",
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.11.tgz",
+      "integrity": "sha512-YOCdxsqbnn/HMPCNM6nrXUpSndLXMUssGTtzT7ffXqr7WuzRg2e170FVDVQFIkb08E7Ku5uOnnUVAChAJQbMOQ==",
       "cpu": [
         "arm64"
       ],
@@ -2196,9 +2274,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.11.tgz",
-      "integrity": "sha512-2mMscXe/ivq8c4tO3eQSbQDFBvagMJGlalXCspn0DgDImLYTEnt/8KHMUMGVfh0gMJTZ9q4FlGLo7mlnbx99MQ==",
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.11.tgz",
+      "integrity": "sha512-nR2tfdQRRzwqR2XYw9NnBk9Fdvff/b8IiJzDL28gRR2QiJWLaE8LsRovtWrzCOYq6o5Uu9cJ3WbabWthLo4jLw==",
       "cpu": [
         "arm64"
       ],
@@ -2213,9 +2291,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.11.tgz",
-      "integrity": "sha512-eu2apgDbC4xwsigpl6LS+iyw6a3mL6kB4I+6PZMbFF2nIb1Dh7RGnu70Ai6mMn1o80fTmRSKsCT3CKMfVdeNFg==",
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.11.tgz",
+      "integrity": "sha512-b4gBp5HA9xNWNC5gsYbdzGBJWx4vKSGybGMGOVWWuF+ynx10+0sA/o4XJGuNHm8TEDuNh9YLKf6QkIO8+GPJ1g==",
       "cpu": [
         "x64"
       ],
@@ -2230,9 +2308,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.11.tgz",
-      "integrity": "sha512-0n+wPWpDigwqRay4IL2JIvAqSKCXv6nKxPig9M7+epAlEQlqX+8Oq/Ap3yHtuhjNPb7HmnqNJLCXT1Wx+BZo0w==",
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.11.tgz",
+      "integrity": "sha512-dEvqmQVswjNvMBwXNb8q5uSvhWrJLdttBSef3s6UC5oDSwOr00t3RQPzyS3n5qmGJ8UMTdPRmsopxmqaODISdg==",
       "cpu": [
         "x64"
       ],
@@ -2247,9 +2325,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.11.tgz",
-      "integrity": "sha512-7+bMSIoqcbXKosIVd314YjckDRPneA4OpG1cb3/GrkQTEDXmWT3pFBBlJf82hzJfw7b6lfv6rDVEFBX7/PJoLA==",
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.11.tgz",
+      "integrity": "sha512-aZNZznem9WRnw2FbTqVpnclvl8Q2apOBW2B316gZK+qxbe+ktjOUnYaMhdCG3+BYggyIBDOnaJeQrXbKIMmNdw==",
       "cpu": [
         "arm64"
       ],
@@ -2264,9 +2342,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.11.tgz",
-      "integrity": "sha512-6hkLl4+3KjP/OFTryWxpW7YFN+w4R689TSPwiII4fFgsFNupyEmLWWakKfkGgV2JVA59L4Oi02elHy/O1sbgtw==",
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.11.tgz",
+      "integrity": "sha512-DjeJn/IfjgOddmJ8IBbWuDK53Fqw7UvOz7kyI/728CSdDYC3LXigzj3ZYs4VvyeOt+ZcQZUB2HA27edOifomGw==",
       "cpu": [
         "ia32"
       ],
@@ -2281,9 +2359,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.11.tgz",
-      "integrity": "sha512-kKNE2BGu/La2k2WFHovenqZvGQAHRIU+rd2/6a7D6EiQ6EyimtbhUqjCCZ+N1f5fIAnvM+sMdLiQJq4jdd/oOQ==",
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.11.tgz",
+      "integrity": "sha512-Gp/SLoeMtsU4n0uRoKDOlGrRC6wCfifq7bqLwSlAG8u8MyJYJCcwjg7ggm0rhLdC2vbiZ+lLVl3kkETp+JUvKg==",
       "cpu": [
         "x64"
       ],
@@ -2315,13 +2393,23 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
-      "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.19.tgz",
+      "integrity": "sha512-WkAZaAfj44kh/UFdAQcrMP1I0nwRqpt27u+08LMBYMqmQfwwMofYoMh/48NGkMMRfC4ynpfwRbJuu8ErfNloeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/estree": {
@@ -2345,20 +2433,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.22.0.tgz",
-      "integrity": "sha512-4Uta6REnz/xEJMvwf72wdUnC3rr4jAQf5jnTkeRQ9b6soxLxhDEbS/pfMPoJLDfFPNVRdryqWUIV/2GZzDJFZw==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.1.tgz",
+      "integrity": "sha512-2X3mwqsj9Bd3Ciz508ZUtoQQYpOhU/kWoUqIf49H8Z0+Vbh6UF/y0OEYp0Q0axOGzaBGs7QxRwq0knSQ8khQNA==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.22.0",
-        "@typescript-eslint/type-utils": "8.22.0",
-        "@typescript-eslint/utils": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0",
+        "@typescript-eslint/scope-manager": "8.26.1",
+        "@typescript-eslint/type-utils": "8.26.1",
+        "@typescript-eslint/utils": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2370,19 +2458,19 @@
       "peerDependencies": {
         "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.22.0.tgz",
-      "integrity": "sha512-MqtmbdNEdoNxTPzpWiWnqNac54h8JDAmkWtJExBVVnSrSmi9z+sZUt0LfKqk9rjqmKOIeRhO4fHHJ1nQIjduIQ==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.1.tgz",
+      "integrity": "sha512-w6HZUV4NWxqd8BdeFf81t07d7/YV9s7TCWrQQbG5uhuvGUAW+fq1usZ1Hmz9UPNLniFnD8GLSsDpjP0hm1S4lQ==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.22.0",
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/typescript-estree": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0",
+        "@typescript-eslint/scope-manager": "8.26.1",
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/typescript-estree": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2394,17 +2482,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.22.0.tgz",
-      "integrity": "sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.1.tgz",
+      "integrity": "sha512-6EIvbE5cNER8sqBu6V7+KeMZIC1664d2Yjt+B9EWUXrsyWpxx4lEZrmvxgSKRC6gX+efDL/UY9OpPZ267io3mg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0"
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2415,15 +2503,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.22.0.tgz",
-      "integrity": "sha512-NzE3aB62fDEaGjaAYZE4LH7I1MUwHooQ98Byq0G0y3kkibPJQIXVUspzlFOmOfHhiDLwKzMlWxaNv+/qcZurJA==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.26.1.tgz",
+      "integrity": "sha512-Kcj/TagJLwoY/5w9JGEFV0dclQdyqw9+VMndxOJKtoFSjfZhLXhYjzsQEeyza03rwHx2vFEGvrJWJBXKleRvZg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.22.0",
-        "@typescript-eslint/utils": "8.22.0",
+        "@typescript-eslint/typescript-estree": "8.26.1",
+        "@typescript-eslint/utils": "8.26.1",
         "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2434,13 +2522,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.22.0.tgz",
-      "integrity": "sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.1.tgz",
+      "integrity": "sha512-n4THUQW27VmQMx+3P+B0Yptl7ydfceUj4ON/AQILAASwgYdZ/2dhfymRMh5egRUrvK5lSmaOm77Ry+lmXPOgBQ==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2451,19 +2539,19 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.22.0.tgz",
-      "integrity": "sha512-SJX99NAS2ugGOzpyhMza/tX+zDwjvwAtQFLsBo3GQxiGcvaKlqGBkmZ+Y1IdiSi9h4Q0Lr5ey+Cp9CGWNY/F/w==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.1.tgz",
+      "integrity": "sha512-yUwPpUHDgdrv1QJ7YQal3cMVBGWfnuCdKbXw1yyjArax3353rEJP1ZA+4F8nOlQ3RfS2hUN/wze3nlY+ZOhvoA==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0",
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/visitor-keys": "8.26.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2473,7 +2561,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -2501,15 +2589,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.22.0.tgz",
-      "integrity": "sha512-T8oc1MbF8L+Bk2msAvCUzjxVB2Z2f+vXYfcucE2wOmYs7ZUwco5Ep0fYZw8quNwOiw9K8GYVL+Kgc2pETNTLOg==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.1.tgz",
+      "integrity": "sha512-V4Urxa/XtSUroUrnI7q6yUTD3hDtfJ2jzVfeT3VK0ciizfK2q/zGC0iDh1lFMUZR8cImRrep6/q0xd/1ZGPQpg==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.22.0",
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/typescript-estree": "8.22.0"
+        "@typescript-eslint/scope-manager": "8.26.1",
+        "@typescript-eslint/types": "8.26.1",
+        "@typescript-eslint/typescript-estree": "8.26.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2520,16 +2608,16 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.22.0.tgz",
-      "integrity": "sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.1.tgz",
+      "integrity": "sha512-AjOC3zfnxd6S4Eiy3jwktJPclqhFHNyd8L6Gycf9WUPoKZpgM5PjkxY1X7uSy61xVpiJDhhk7XT2NVsN3ALTWg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
+        "@typescript-eslint/types": "8.26.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -2539,6 +2627,152 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@unrs/rspack-resolver-binding-darwin-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-darwin-arm64/-/rspack-resolver-binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-xgSjy64typsn/lhQk/uKaS363H7ZeIBlWSh25FJFWXSCeLMHpEZ0umDo5Vzqi5iS26OZ5R1SpQkwiS78GhQRjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/rspack-resolver-binding-darwin-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-darwin-x64/-/rspack-resolver-binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-3maDtW0vehzciEbuLxc2g+0FmDw5LGfCt+yMN1ZDn0lW0ikEBEFp6ul3h2fRphtfuCc7IvBJE9WWTt1UHkS7Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/rspack-resolver-binding-freebsd-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-freebsd-x64/-/rspack-resolver-binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-aN6ifws9rNLjK2+6sIU9wvHyjXEf3S5+EZTHRarzd4jfa8i5pA7Mwt28un2DZVrBtIxhWDQvUPVKGI7zSBfVCA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/rspack-resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm-gnueabihf/-/rspack-resolver-binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-tKqu9VQyCO1yEUX6n6jgOHi7SJA9e6lvHczK60gur4VBITxnPmVYiCj2aekrOOIavvvjjuWAL2rqPQuc4g7RHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/rspack-resolver-binding-linux-arm64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm64-gnu/-/rspack-resolver-binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-+xDI0kvwPiCR7334O83TPfaUXSe0UMVi5srQpQxP4+SDVYuONWsbwAC1IXe+yfOwRVGZsUdW9wE0ZiWs4Z+egw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/rspack-resolver-binding-linux-arm64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm64-musl/-/rspack-resolver-binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-fcrVHlw+6UgQliMbI0znFD4ASWKuyY17FdH67ZmyNH62b0hRhhxQuJE0D6N3410m8lKVu4QW4EzFiHxYFUC0cg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/rspack-resolver-binding-linux-x64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-x64-gnu/-/rspack-resolver-binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-xISTyUJ2PiAT4x9nlh8FdciDcdKbsatgK9qO7EEsILt9VB7Y1mHYGaszj3ouxfZnaKQ13WwW+dFLGxkZLP/WVg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/rspack-resolver-binding-linux-x64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-x64-musl/-/rspack-resolver-binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-LE8EjE/iPlvSsFbZ6P9c0Jh5/pifAi03UYeXYwOnQqt1molKAPMB0R4kGWOM7dnDYaNgkk1MN9MOTCLsqe97Fw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/rspack-resolver-binding-wasm32-wasi": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-wasm32-wasi/-/rspack-resolver-binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-XERT3B88+G55RgG96May8QvAdgGzHr8qtQ70cIdbuWTpIcA0I76cnxSZ8Qwx33y73jE5N/myX2YKDlFksn4z6w==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/rspack-resolver-binding-win32-arm64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-win32-arm64-msvc/-/rspack-resolver-binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-I8OLI6JbmNx2E/SG8MOEuo/d6rNx8dwgL09rcItSMcP82v1oZ8AY8HNA+axxuxEH95nkb6MPJU09p63isDvzrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/rspack-resolver-binding-win32-x64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-win32-x64-msvc/-/rspack-resolver-binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-s5WvCljhFqiE3McvaD3lDIsQpmk7gEJRUHy1PRwLPzEB7snq9P2xQeqgzdjGhJQq62jBFz7NDy7NbMkocWr2pw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/acorn": {
       "version": "8.14.0",
@@ -2781,9 +3015,9 @@
       "license": "MIT"
     },
     "node_modules/base-x": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
-      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2902,9 +3136,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001695",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
-      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
+      "version": "1.0.30001706",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001706.tgz",
+      "integrity": "sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==",
       "dev": true,
       "funding": [
         {
@@ -3271,24 +3505,11 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.88",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.88.tgz",
-      "integrity": "sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==",
+      "version": "1.5.120",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.120.tgz",
+      "integrity": "sha512-oTUp3gfX1gZI+xfD2djr2rzQdHCwHzPQrrK0CD7WpTdF0nPdQ/INcRVjWgLdCT4a9W3jFObR9DAfsuyFQnI8CQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
-      "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -3602,22 +3823,19 @@
       }
     },
     "node_modules/eslint-import-resolver-typescript": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.7.0.tgz",
-      "integrity": "sha512-Vrwyi8HHxY97K5ebydMtffsWAn1SCR9eol49eCd5fJS4O1WV7PaAjbcjmbfJJSMz/t4Mal212Uz/fQZrOB8mow==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.2.1.tgz",
+      "integrity": "sha512-jAAKR08YRFtlRpxK3OnixV0JB88lH3Xo7HWn1KpKlEvtVUlLMAcRCcBvWT1KAnfT4jPAs4veyFxuUqSdg/Vd3g==",
       "license": "ISC",
       "dependencies": {
-        "@nolyfill/is-core-module": "1.0.39",
-        "debug": "^4.3.7",
-        "enhanced-resolve": "^5.15.0",
-        "fast-glob": "^3.3.2",
-        "get-tsconfig": "^4.7.5",
-        "is-bun-module": "^1.0.2",
-        "is-glob": "^4.0.3",
-        "stable-hash": "^0.0.4"
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "rspack-resolver": "^1.2.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.12"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^16.17.0 || >=18.6.0"
       },
       "funding": {
         "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
@@ -3625,13 +3843,17 @@
       "peerDependencies": {
         "eslint": "*",
         "eslint-plugin-import": "*",
-        "eslint-plugin-import-x": "*"
+        "eslint-plugin-import-x": "*",
+        "is-bun-module": "*"
       },
       "peerDependenciesMeta": {
         "eslint-plugin-import": {
           "optional": true
         },
         "eslint-plugin-import-x": {
+          "optional": true
+        },
+        "is-bun-module": {
           "optional": true
         }
       }
@@ -3849,6 +4071,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/eslint-plugin-prefer-arrow-functions/node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.3.tgz",
@@ -3912,9 +4148,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz",
-      "integrity": "sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3924,9 +4160,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.18.tgz",
-      "integrity": "sha512-IRGEoFn3OKalm3hjfolEWGqoF/jPqeEYFp+C8B0WMzwGwBMvlRDQd06kghDhF0C61uJ6WfSDhEZE/sAQjduKgw==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.19.tgz",
+      "integrity": "sha512-eyy8pcr/YxSYjBoqIFSrlbn9i/xvxUFa8CjzAYo9cFjgGXqq1hyjihcpZvxRLalpaWmueWR81xn7vuKmAFijDQ==",
       "license": "MIT",
       "peerDependencies": {
         "eslint": ">=8.40"
@@ -3985,6 +4221,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
+      "integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/espree": {
@@ -4319,9 +4565,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
-      "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
+      "integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4357,12 +4603,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -4653,6 +4893,8 @@
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-1.3.0.tgz",
       "integrity": "sha512-DgXeu5UWI0IsMQundYb5UAOzm6G2eVnarJ0byP6Tm55iZNKceD59LNPA2L4VvsScTtHcw0yEkVwSf7PC+QoLSA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "semver": "^7.6.3"
       }
@@ -5080,13 +5322,13 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.1.tgz",
-      "integrity": "sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==",
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.3.tgz",
+      "integrity": "sha512-GlOJwTIP6TMIlrTFsxTerwC0W6OpQpCGuX1ECRLBUVRh6fpJH3xTqjCjRgQHTb4ZXexH9rtHou1Lf03GKzmhhQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "detect-libc": "^1.0.3"
+        "detect-libc": "^2.0.3"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -5096,22 +5338,22 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.29.1",
-        "lightningcss-darwin-x64": "1.29.1",
-        "lightningcss-freebsd-x64": "1.29.1",
-        "lightningcss-linux-arm-gnueabihf": "1.29.1",
-        "lightningcss-linux-arm64-gnu": "1.29.1",
-        "lightningcss-linux-arm64-musl": "1.29.1",
-        "lightningcss-linux-x64-gnu": "1.29.1",
-        "lightningcss-linux-x64-musl": "1.29.1",
-        "lightningcss-win32-arm64-msvc": "1.29.1",
-        "lightningcss-win32-x64-msvc": "1.29.1"
+        "lightningcss-darwin-arm64": "1.29.3",
+        "lightningcss-darwin-x64": "1.29.3",
+        "lightningcss-freebsd-x64": "1.29.3",
+        "lightningcss-linux-arm-gnueabihf": "1.29.3",
+        "lightningcss-linux-arm64-gnu": "1.29.3",
+        "lightningcss-linux-arm64-musl": "1.29.3",
+        "lightningcss-linux-x64-gnu": "1.29.3",
+        "lightningcss-linux-x64-musl": "1.29.3",
+        "lightningcss-win32-arm64-msvc": "1.29.3",
+        "lightningcss-win32-x64-msvc": "1.29.3"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.1.tgz",
-      "integrity": "sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==",
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.3.tgz",
+      "integrity": "sha512-fb7raKO3pXtlNbQbiMeEu8RbBVHnpyqAoxTyTRMEWFQWmscGC2wZxoHzZ+YKAepUuKT9uIW5vL2QbFivTgprZg==",
       "cpu": [
         "arm64"
       ],
@@ -5130,9 +5372,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.1.tgz",
-      "integrity": "sha512-k33G9IzKUpHy/J/3+9MCO4e+PzaFblsgBjSGlpAaFikeBFm8B/CkO3cKU9oI4g+fjS2KlkLM/Bza9K/aw8wsNA==",
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.3.tgz",
+      "integrity": "sha512-KF2XZ4ZdmDGGtEYmx5wpzn6u8vg7AdBHaEOvDKu8GOs7xDL/vcU2vMKtTeNe1d4dogkDdi3B9zC77jkatWBwEQ==",
       "cpu": [
         "x64"
       ],
@@ -5151,9 +5393,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.1.tgz",
-      "integrity": "sha512-0SUW22fv/8kln2LnIdOCmSuXnxgxVC276W5KLTwoehiO0hxkacBxjHOL5EtHD8BAXg2BvuhsJPmVMasvby3LiQ==",
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.3.tgz",
+      "integrity": "sha512-VUWeVf+V1UM54jv9M4wen9vMlIAyT69Krl9XjI8SsRxz4tdNV/7QEPlW6JASev/pYdiynUCW0pwaFquDRYdxMw==",
       "cpu": [
         "x64"
       ],
@@ -5172,9 +5414,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.1.tgz",
-      "integrity": "sha512-sD32pFvlR0kDlqsOZmYqH/68SqUMPNj+0pucGxToXZi4XZgZmqeX/NkxNKCPsswAXU3UeYgDSpGhu05eAufjDg==",
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.3.tgz",
+      "integrity": "sha512-UhgZ/XVNfXQVEJrMIWeK1Laj8KbhjbIz7F4znUk7G4zeGw7TRoJxhb66uWrEsonn1+O45w//0i0Fu0wIovYdYg==",
       "cpu": [
         "arm"
       ],
@@ -5193,9 +5435,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.1.tgz",
-      "integrity": "sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==",
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.3.tgz",
+      "integrity": "sha512-Pqau7jtgJNmQ/esugfmAT1aCFy/Gxc92FOxI+3n+LbMHBheBnk41xHDhc0HeYlx9G0xP5tK4t0Koy3QGGNqypw==",
       "cpu": [
         "arm64"
       ],
@@ -5214,9 +5456,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.1.tgz",
-      "integrity": "sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==",
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.3.tgz",
+      "integrity": "sha512-dxakOk66pf7KLS7VRYFO7B8WOJLecE5OPL2YOk52eriFd/yeyxt2Km5H0BjLfElokIaR+qWi33gB8MQLrdAY3A==",
       "cpu": [
         "arm64"
       ],
@@ -5235,9 +5477,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.1.tgz",
-      "integrity": "sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==",
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.3.tgz",
+      "integrity": "sha512-ySZTNCpbfbK8rqpKJeJR2S0g/8UqqV3QnzcuWvpI60LWxnFN91nxpSSwCbzfOXkzKfar9j5eOuOplf+klKtINg==",
       "cpu": [
         "x64"
       ],
@@ -5256,9 +5498,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.1.tgz",
-      "integrity": "sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==",
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.3.tgz",
+      "integrity": "sha512-3pVZhIzW09nzi10usAXfIGTTSTYQ141dk88vGFNCgawIzayiIzZQxEcxVtIkdvlEq2YuFsL9Wcj/h61JHHzuFQ==",
       "cpu": [
         "x64"
       ],
@@ -5277,9 +5519,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.1.tgz",
-      "integrity": "sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==",
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.3.tgz",
+      "integrity": "sha512-VRnkAvtIkeWuoBJeGOTrZxsNp4HogXtcaaLm8agmbYtLDOhQdpgxW6NjZZjDXbvGF+eOehGulXZ3C1TiwHY4QQ==",
       "cpu": [
         "arm64"
       ],
@@ -5298,9 +5540,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.1.tgz",
-      "integrity": "sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q==",
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.3.tgz",
+      "integrity": "sha512-IszwRPu2cPnDQsZpd7/EAr0x2W7jkaWqQ1SwCVIZ/tSbZVXPLt6k8s6FkcyBjViCzvB5CW0We0QbbP7zp2aBjQ==",
       "cpu": [
         "x64"
       ],
@@ -5316,6 +5558,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lines-and-columns": {
@@ -5752,24 +6004,24 @@
       }
     },
     "node_modules/parcel": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.13.3.tgz",
-      "integrity": "sha512-8GrC8C7J8mwRpAlk7EJ7lwdFTbCN+dcXH2gy5AsEs9pLfzo9wvxOTx6W0fzSlvCOvZOita+8GdfYlGfEt0tRgA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.14.0.tgz",
+      "integrity": "sha512-STnHivKaXYDOcLDXO3ScfrpgoM7UIoQk84yUj0DTMQAij6+/m2q8ItrVf2kHzxMj+UwP4JP7DbfVz9l6/K2nnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/config-default": "2.13.3",
-        "@parcel/core": "2.13.3",
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/events": "2.13.3",
-        "@parcel/feature-flags": "2.13.3",
-        "@parcel/fs": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/package-manager": "2.13.3",
-        "@parcel/reporter-cli": "2.13.3",
-        "@parcel/reporter-dev-server": "2.13.3",
-        "@parcel/reporter-tracer": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/config-default": "2.14.0",
+        "@parcel/core": "2.14.0",
+        "@parcel/diagnostic": "2.14.0",
+        "@parcel/events": "2.14.0",
+        "@parcel/feature-flags": "2.14.0",
+        "@parcel/fs": "2.14.0",
+        "@parcel/logger": "2.14.0",
+        "@parcel/package-manager": "2.14.0",
+        "@parcel/reporter-cli": "2.14.0",
+        "@parcel/reporter-dev-server": "2.14.0",
+        "@parcel/reporter-tracer": "2.14.0",
+        "@parcel/utils": "2.14.0",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "get-port": "^4.2.0"
@@ -6176,13 +6428,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/react-error-overlay": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
-      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6190,9 +6435,9 @@
       "license": "MIT"
     },
     "node_modules/react-refresh": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
-      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.16.0.tgz",
+      "integrity": "sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6294,6 +6539,28 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rspack-resolver": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rspack-resolver/-/rspack-resolver-1.2.1.tgz",
+      "integrity": "sha512-yTaWGUvHOjcoyFMdVTdYt2nq2Hu8sw6ia3X9szloXFJlWLQZnQ9g/4TPhL3Bb3qN58Mkye8mFG7MCaKhya7fOw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/JounQin"
+      },
+      "optionalDependencies": {
+        "@unrs/rspack-resolver-binding-darwin-arm64": "1.2.1",
+        "@unrs/rspack-resolver-binding-darwin-x64": "1.2.1",
+        "@unrs/rspack-resolver-binding-freebsd-x64": "1.2.1",
+        "@unrs/rspack-resolver-binding-linux-arm-gnueabihf": "1.2.1",
+        "@unrs/rspack-resolver-binding-linux-arm64-gnu": "1.2.1",
+        "@unrs/rspack-resolver-binding-linux-arm64-musl": "1.2.1",
+        "@unrs/rspack-resolver-binding-linux-x64-gnu": "1.2.1",
+        "@unrs/rspack-resolver-binding-linux-x64-musl": "1.2.1",
+        "@unrs/rspack-resolver-binding-wasm32-wasi": "1.2.1",
+        "@unrs/rspack-resolver-binding-win32-arm64-msvc": "1.2.1",
+        "@unrs/rspack-resolver-binding-win32-x64-msvc": "1.2.1"
       }
     },
     "node_modules/run-parallel": {
@@ -6561,9 +6828,9 @@
       }
     },
     "node_modules/stable-hash": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.4.tgz",
-      "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "license": "MIT"
     },
     "node_modules/string.prototype.matchall": {
@@ -6721,15 +6988,6 @@
         "url": "https://opencollective.com/unts"
       }
     },
-    "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -6750,6 +7008,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6763,9 +7063,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
-      "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
+      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
       "license": "MIT",
       "engines": {
         "node": ">=18.12"
@@ -6905,9 +7205,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6918,14 +7218,14 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.22.0.tgz",
-      "integrity": "sha512-Y2rj210FW1Wb6TWXzQc5+P+EWI9/zdS57hLEc0gnyuvdzWo8+Y8brKlbj0muejonhMI/xAZCnZZwjbIfv1CkOw==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.26.1.tgz",
+      "integrity": "sha512-t/oIs9mYyrwZGRpDv3g+3K6nZ5uhKEMt2oNmAPwaY4/ye0+EH4nXIPYNtkYFS6QHm+1DFg34DbglYBz5P9Xysg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.22.0",
-        "@typescript-eslint/parser": "8.22.0",
-        "@typescript-eslint/utils": "8.22.0"
+        "@typescript-eslint/eslint-plugin": "8.26.1",
+        "@typescript-eslint/parser": "8.26.1",
+        "@typescript-eslint/utils": "8.26.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6936,7 +7236,7 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -6958,9 +7258,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
-      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -32,18 +32,18 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@eslint/js": "^9.19.0",
+    "@eslint/js": "^9.22.0",
     "eslint-config-prettier": "^10",
-    "eslint-import-resolver-typescript": "^3.7.0",
+    "eslint-import-resolver-typescript": "^4.2.1",
     "eslint-plugin-import": "^2",
     "eslint-plugin-prefer-arrow-functions": "^3.6.2",
     "eslint-plugin-prettier": "^5",
     "eslint-plugin-react": "^7.37.4",
-    "eslint-plugin-react-hooks": "^5.1.0",
-    "eslint-plugin-react-refresh": "^0.4.18",
-    "globals": "^15.14.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.19",
+    "globals": "^16.0.0",
     "prettier-plugin-tailwindcss": "^0.6.11",
-    "typescript-eslint": "^8.22.0"
+    "typescript-eslint": "^8.26.1"
   },
   "peerDependencies": {
     "eslint": "^9",
@@ -53,9 +53,9 @@
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
   "devDependencies": {
-    "@parcel/packager-ts": "^2.13.3",
-    "@parcel/transformer-typescript-types": "^2.13.3",
-    "parcel": "^2.13.3",
-    "typescript": "^5.7.3"
+    "@parcel/packager-ts": "^2.14.0",
+    "@parcel/transformer-typescript-types": "^2.14.0",
+    "parcel": "^2.14.0",
+    "typescript": "^5.8.2"
   }
 }

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -34,7 +34,7 @@ type EslintConfigParams = {
   /**
    * Changes every rule to "warning" instead of "error".
    * This prevents ESLint to fail if any rule fails.
-   * Use with caution.
+   * Useful when migrating large codebases. Use with caution.
    * */
   changeEveryRuleToWarning?: boolean;
 };

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -31,11 +31,18 @@ type EslintConfigParams = {
    * Required if there are multiple files with references.
    * */
   tsConfigsDirs?: string[];
+  /**
+   * Changes every rule to "warning" instead of "error".
+   * This prevents ESLint to fail if any rule fails.
+   * Use with caution.
+   * */
+  changeEveryRuleToWarning?: boolean;
 };
 
 export const getEslintConfig = ({
   tsconfigRootDir,
   tsConfigsDirs = [],
+  changeEveryRuleToWarning,
 }: EslintConfigParams) => {
   /**
    * Completely ignores these directories
@@ -271,6 +278,22 @@ export const getEslintConfig = ({
   };
 
   /**
+   * Transforms ALL rules severities to 'warn'
+   * */
+  const transformAllRulesToWarn: InfiniteDepthConfigWithExtends = {
+    rules: {},
+    languageOptions: {},
+    processor: {
+      preprocess: (text) => [text],
+      postprocess: (messages) =>
+        messages[0].map((message: any) => ({
+          ...message,
+          severity: 1, // 1 is 'warn', 2 is 'error'
+        })),
+    },
+  };
+
+  /**
    * Forces correct prettier formatting with auto-fix support
    * */
   const prettierPlugin = eslintPluginPrettierRecommended;
@@ -285,5 +308,6 @@ export const getEslintConfig = ({
     ...reactPlugins,
     prettierPlugin,
     ignoreDefaultExportRule,
+    changeEveryRuleToWarning ? transformAllRulesToWarn : {},
   );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "incremental": true,
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# Split ESLint config into smaller parts, improving documentation

## :recycle: Current situation & Problem
To make it easier for people to adopt and extend, ESLint configs could be modularized and documented better. This is first step. 


## :gear: Release Notes
* Update packages
* Split ESLint config into sections, document them
* Add new `changeEveryRuleToWarning` parameter. It makes it easier for people to gradually adopt to ESLint config.


## :white_check_mark: Testing
I checked it against https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend locally.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
