### PR TITLE
Add ".next" directory to global ignores

### DIFF
--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -48,7 +48,7 @@ export const getEslintConfig = ({
    * Completely ignores these directories
    * */
   const ignoredDirs: InfiniteDepthConfigWithExtends = {
-    ignores: ["dist", "docs", "out", "coverage"],
+    ignores: ["dist", "docs", "out", "coverage", ".next"],
   };
 
   /**

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -48,7 +48,14 @@ export const getEslintConfig = ({
    * Completely ignores these directories
    * */
   const ignoredDirs: InfiniteDepthConfigWithExtends = {
-    ignores: ["dist", "docs", "out", "coverage", ".next"],
+    ignores: [
+      "dist",
+      "docs",
+      "out",
+      "coverage",
+      ".next",
+      "**/playwright-report",
+    ],
   };
 
   /**


### PR DESCRIPTION
# Add ".next" directory to global ignores

## :recycle: Current situation & Problem
`.next` directory doesn't need to be scanned for ESLint. 


## :gear: Release Notes
* Add ".next" directory to global ignores
* Add **/playwright-report to ignore


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
