### PR TITLE
Forbid `e` as variable name

### DIFF
--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -16,6 +16,7 @@ import reactPlugin from "eslint-plugin-react";
 // @ts-ignore
 import * as preferArrow from "eslint-plugin-prefer-arrow-functions";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
+import type { Linter } from "@typescript-eslint/utils/ts-eslint";
 // require is necessary to prevent Parcel from treating it as ESM
 // @ts-ignore
 const importPlugin = require("eslint-plugin-import");
@@ -178,6 +179,20 @@ export const getEslintConfig = ({
         tsconfigRootDir,
       },
     },
+    processor: {
+      preprocess: (text) => [text],
+      postprocess: (messagesList: Linter.LintMessage[][]) =>
+        messagesList[0].map((message) => {
+          if (message.ruleId === "@typescript-eslint/naming-convention") {
+            return {
+              ...message,
+              message:
+                "Variable name `e` is not allowed. Use more descriptive name: error, event",
+            };
+          }
+          return message;
+        }),
+    },
     rules: {
       "@typescript-eslint/consistent-type-imports": [
         "warn",
@@ -224,6 +239,25 @@ export const getEslintConfig = ({
       ],
       // notFound in Tanstack Router is thrown
       "@typescript-eslint/only-throw-error": "off",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          selector: "variable",
+          format: null,
+          custom: {
+            regex: "^e$",
+            match: false,
+          },
+        },
+        {
+          selector: "parameter",
+          format: null,
+          custom: {
+            regex: "^e$",
+            match: false,
+          },
+        },
+      ],
     },
   };
 

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -187,7 +187,7 @@ export const getEslintConfig = ({
             return {
               ...message,
               message:
-                "Variable name `e` is not allowed. Use more descriptive name: error, event",
+                "Variable name `e` is not allowed. Use a more descriptive name like `error` or `event`.",
             };
           }
           return message;


### PR DESCRIPTION
# Forbid `e` as variable name

## :recycle: Current situation & Problem
Developers tend to use `e` for event callbacks:

```
onClick={(e) => e.preventDefault()}
```

and for errors:

```
try {
  ...
} catch (e) {
  
}
```

It decreases readability, as both names can be used for one name. 

This PR adds ESLint rule that bans using `e` as variable or parameter name. 


## :gear: Release Notes
* Forbid `e` as variable name


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
