### PR TITLE
Exclude ESLint and Prettier from default exports ban rule

### DIFF
--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -321,6 +321,8 @@ export const getEslintConfig = ({
       "**/vite.config.ts",
       "**/*.stories.ts?(x)",
       "**/.storybook/**/*.ts?(x)",
+      "**/.prettierrc.{ts,js}",
+      "**/eslint.config.{ts,js}",
     ],
     rules: {
       "import/no-default-export": "off",


### PR DESCRIPTION
# Exclude ESLint and Prettier from default exports ban rule

## :recycle: Current situation & Problem
ESLint and Prettier configurations must contain default exports.


## :gear: Release Notes
* Exclude ESLint and Prettier from default exports ban rule


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
