### PR TITLE
Fix autofixable rules that include processors

### DIFF
--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -16,7 +16,7 @@ import reactPlugin from "eslint-plugin-react";
 // @ts-ignore
 import * as preferArrow from "eslint-plugin-prefer-arrow-functions";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
-import type { Linter } from "@typescript-eslint/utils/ts-eslint";
+import { Processor } from "@typescript-eslint/utils/ts-eslint";
 // require is necessary to prevent Parcel from treating it as ESM
 // @ts-ignore
 const importPlugin = require("eslint-plugin-import");
@@ -188,8 +188,8 @@ export const getEslintConfig = ({
     },
     processor: {
       preprocess: (text) => [text],
-      postprocess: (messagesList: Linter.LintMessage[][]) =>
-        messagesList[0].map((message) => {
+      postprocess: (messagesList) =>
+        messagesList.flat().map((message) => {
           if (message.ruleId === "@typescript-eslint/naming-convention") {
             return {
               ...message,
@@ -199,7 +199,8 @@ export const getEslintConfig = ({
           }
           return message;
         }),
-    },
+      supportsAutofix: true,
+    } satisfies Processor.ProcessorModule,
     rules: {
       "@typescript-eslint/consistent-type-imports": [
         "warn",
@@ -338,11 +339,12 @@ export const getEslintConfig = ({
     processor: {
       preprocess: (text) => [text],
       postprocess: (messages) =>
-        messages[0].map((message: any) => ({
+        messages.flat().map((message) => ({
           ...message,
           severity: 1, // 1 is 'warn', 2 is 'error'
         })),
-    },
+      supportsAutofix: true,
+    } satisfies Processor.ProcessorModule,
   };
 
   /**


### PR DESCRIPTION
# Fix autofixable rules that include processors

## :recycle: Current situation & Problem
I noticed that auto-fix no longer works properly.

When `processor` is available, ESLint disables auto-fix by default. This is to make sure devs explicitly inform how pre and post processed code position maps. We use processor for two things:

1. Change message of the `@typescript-eslint/naming-convention` rule to ensure better readability
2. Modify rule's severity to warning if necessary.

We can safely enable auto-fix without further modifications, as we use it for misc operations, without transforming the code. 


## :gear: Release Notes
* Enable auto-fix for rules with processor
* Improve type safety of processors


## :white_check_mark: Testing
Tested against ENGAGE-HF-Web-Frontend.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
